### PR TITLE
Updating passthrough to 4.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
-/node_modules/*
+node_modules
 npm-debug.log
+*.tgz
+
+# Uncomment this when published on NPM
+# dist

--- a/.npmigonre
+++ b/.npmigonre
@@ -1,0 +1,16 @@
+# compiled output
+*.ts
+!*.d.ts
+*.tgz
+
+!dist
+
+# dependencies
+node_modules
+
+# npm
+npm-debug.log
+
+# misc
+examples
+tsconfig.json

--- a/dist/index.browser.js
+++ b/dist/index.browser.js
@@ -1,0 +1,279 @@
+(function(e, a) { for(var i in a) e[i] = a[i]; }(exports, /******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+/******/
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// identity function for calling harmony imports with the correct context
+/******/ 	__webpack_require__.i = function(value) { return value; };
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 4);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+/**
+ * UniversalPassthrough browser version - swap server element w/ browser element
+ */
+var core_1 = __webpack_require__(1);
+var PassthroughRegistry = PassthroughRegistry_1 = (function () {
+    function PassthroughRegistry() {
+    }
+    /**
+     * Collenct the server elements
+     */
+    PassthroughRegistry.getServerElements = function () {
+        var serverElements = new Map();
+        var serverElementsArr = [].slice
+            .call(document.querySelectorAll('[universalpassthrough]'));
+        serverElementsArr.forEach(function (el) {
+            // has universalpassthrough attr and an id w/ suffix '-server'
+            if (el.id.match(/-server?/i)) {
+                var browserKey = el.id.replace('-server', '-browser');
+                serverElements.set(browserKey, el);
+            }
+        });
+        return serverElements;
+    };
+    /**
+     * Initialize the registry with the server elements
+     */
+    PassthroughRegistry.init = function () {
+        PassthroughRegistry_1.serverElements = PassthroughRegistry_1.getServerElements();
+    };
+    /**
+     * Check if the browser element is already registered
+     */
+    PassthroughRegistry.prototype.isRegistered = function (id) {
+        return PassthroughRegistry_1.browserElements.has(id);
+    };
+    /**
+     * Register the browser element
+     * Replace it with corresponding server element if found
+     */
+    PassthroughRegistry.prototype.replaceElement = function (browserId, el) {
+        if (PassthroughRegistry_1.serverElements.has(browserId)) {
+            var serverEl_1 = PassthroughRegistry_1.serverElements.get(browserId);
+            if (this.isElement(el) && this.isElement(el.parentNode) && this.isElement(serverEl_1)) {
+                window.requestAnimationFrame(function () {
+                    var browserElement = serverEl_1.cloneNode(true);
+                    el.parentNode.replaceChild(browserElement, el);
+                    PassthroughRegistry_1.serverElements.delete(browserId);
+                });
+            }
+        }
+    };
+    /**
+     * Removes the element from DOM
+     */
+    PassthroughRegistry.prototype.detach = function (id, el) {
+        var serverEl = PassthroughRegistry_1.serverElements.get(id);
+        el.removeChild(serverEl);
+    };
+    /**
+     * Adds the element to DOM
+     */
+    PassthroughRegistry.prototype.reattach = function (id, el) {
+        var serverEl = PassthroughRegistry_1.serverElements.get(id);
+        el.appendChild(serverEl);
+    };
+    PassthroughRegistry.prototype.isElement = function (el) {
+        return (el != null)
+            && (typeof el === 'object')
+            && (el.nodeType === Node.ELEMENT_NODE)
+            && (typeof el.style === 'object')
+            && (typeof el.ownerDocument === 'object');
+    };
+    return PassthroughRegistry;
+}());
+PassthroughRegistry.serverElements = new Map();
+PassthroughRegistry.browserElements = new Map();
+PassthroughRegistry = PassthroughRegistry_1 = __decorate([
+    core_1.Injectable()
+], PassthroughRegistry);
+exports.PassthroughRegistry = PassthroughRegistry;
+var PassthroughRegistry_1;
+
+
+/***/ }),
+/* 1 */
+/***/ (function(module, exports) {
+
+module.exports = require("@angular/core");
+
+/***/ }),
+/* 2 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+var __metadata = (this && this.__metadata) || function (k, v) {
+    if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
+};
+var __param = (this && this.__param) || function (paramIndex, decorator) {
+    return function (target, key) { decorator(target, key, paramIndex); }
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+var core_1 = __webpack_require__(1);
+var passthrough_registry_browser_1 = __webpack_require__(0);
+var UniversalPassthrough = (function () {
+    function UniversalPassthrough(id, passthroughRegistry, elementRef, cdRef) {
+        this.id = id;
+        this.passthroughRegistry = passthroughRegistry;
+        this.elementRef = elementRef;
+        this.cdRef = cdRef;
+        if (this.passthroughRegistry.isRegistered(id)) {
+            this.passthroughRegistry.reattach(id, this.elementRef.nativeElement);
+        }
+        else {
+            this.passthroughRegistry.replaceElement(id, this.elementRef.nativeElement);
+        }
+        cdRef.detach();
+    }
+    UniversalPassthrough.prototype.ngOnDestroy = function () {
+        this.passthroughRegistry.detach(this.id, this.elementRef.nativeElement);
+    };
+    return UniversalPassthrough;
+}());
+UniversalPassthrough = __decorate([
+    core_1.Directive({
+        selector: '[universalPassthrough]'
+    }),
+    __param(0, core_1.Attribute('id')),
+    __metadata("design:paramtypes", [String, passthrough_registry_browser_1.PassthroughRegistry,
+        core_1.ElementRef,
+        core_1.ChangeDetectorRef])
+], UniversalPassthrough);
+exports.UniversalPassthrough = UniversalPassthrough;
+
+
+/***/ }),
+/* 3 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+var core_1 = __webpack_require__(1);
+var passthrough_registry_browser_1 = __webpack_require__(0);
+var passthrough_directive_browser_1 = __webpack_require__(2);
+var UniversalPassthroughModule = (function () {
+    function UniversalPassthroughModule() {
+    }
+    return UniversalPassthroughModule;
+}());
+UniversalPassthroughModule = __decorate([
+    core_1.NgModule({
+        providers: [
+            passthrough_registry_browser_1.PassthroughRegistry
+        ],
+        declarations: [
+            passthrough_directive_browser_1.UniversalPassthrough
+        ],
+        exports: [
+            passthrough_directive_browser_1.UniversalPassthrough
+        ]
+    })
+], UniversalPassthroughModule);
+exports.UniversalPassthroughModule = UniversalPassthroughModule;
+
+
+/***/ }),
+/* 4 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+function __export(m) {
+    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
+}
+Object.defineProperty(exports, "__esModule", { value: true });
+/**
+ * UniversalPassthrough barrel.
+ */
+__export(__webpack_require__(0));
+__export(__webpack_require__(2));
+__export(__webpack_require__(3));
+
+
+/***/ })
+/******/ ])));

--- a/dist/index.server.js
+++ b/dist/index.server.js
@@ -1,0 +1,197 @@
+(function(e, a) { for(var i in a) e[i] = a[i]; }(exports, /******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+/******/
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// identity function for calling harmony imports with the correct context
+/******/ 	__webpack_require__.i = function(value) { return value; };
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 4);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+/**
+ * UniversalPassthrough server version, no-op.
+ */
+
+Object.defineProperty(exports, "__esModule", { value: true });
+var PassthroughRegistry = (function () {
+    function PassthroughRegistry() {
+    }
+    /**
+     * Initialize the registry with the server elements
+     */
+    PassthroughRegistry.init = function () { };
+    /**
+     * Check if the browser element is already registered
+     */
+    PassthroughRegistry.prototype.isRegistered = function (id) { return true; };
+    /**
+     * Register the browser element
+     * Replace it with corresponding server element if found
+     */
+    PassthroughRegistry.prototype.replaceElement = function (browserId, el) { };
+    /**
+     * Removes the element from DOM
+     */
+    PassthroughRegistry.prototype.detach = function (id, el) { };
+    /**
+     * Adds the element to DOM
+     */
+    PassthroughRegistry.prototype.reattach = function (id, el) { };
+    return PassthroughRegistry;
+}());
+exports.PassthroughRegistry = PassthroughRegistry;
+
+
+/***/ }),
+/* 1 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+var core_1 = __webpack_require__(2);
+var UniversalPassthrough = (function () {
+    function UniversalPassthrough() {
+    }
+    return UniversalPassthrough;
+}());
+UniversalPassthrough = __decorate([
+    core_1.Directive({
+        selector: '[universalPassthrough]'
+    })
+], UniversalPassthrough);
+exports.UniversalPassthrough = UniversalPassthrough;
+
+
+/***/ }),
+/* 2 */
+/***/ (function(module, exports) {
+
+module.exports = require("@angular/core");
+
+/***/ }),
+/* 3 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+var core_1 = __webpack_require__(2);
+var passthrough_registry_server_1 = __webpack_require__(0);
+var passthrough_directive_server_1 = __webpack_require__(1);
+var UniversalPassthroughModule = (function () {
+    function UniversalPassthroughModule() {
+    }
+    return UniversalPassthroughModule;
+}());
+UniversalPassthroughModule = __decorate([
+    core_1.NgModule({
+        providers: [
+            passthrough_registry_server_1.PassthroughRegistry
+        ],
+        declarations: [
+            passthrough_directive_server_1.UniversalPassthrough
+        ],
+        exports: [
+            passthrough_directive_server_1.UniversalPassthrough
+        ]
+    })
+], UniversalPassthroughModule);
+exports.UniversalPassthroughModule = UniversalPassthroughModule;
+
+
+/***/ }),
+/* 4 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+function __export(m) {
+    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
+}
+Object.defineProperty(exports, "__esModule", { value: true });
+/**
+ * UniversalPassthrough barrel.
+ */
+__export(__webpack_require__(0));
+__export(__webpack_require__(1));
+__export(__webpack_require__(3));
+
+
+/***/ })
+/******/ ])));

--- a/examples/banner-ad/package.json
+++ b/examples/banner-ad/package.json
@@ -5,9 +5,6 @@
   "main": "index.server",
   "typings": "index.server",
   "browser": "index.browser",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
   "contributors": [
     "PatrickJS <patrick@angularclass.com>",
     "Shawn Stedman <sstedman@pxwise.com>"

--- a/index.server.ts
+++ b/index.server.ts
@@ -4,5 +4,3 @@
 export * from './passthrough-registry.server';
 export * from './passthrough.directive.server';
 export * from './passthrough.module.server';
-
-

--- a/index.ts
+++ b/index.ts
@@ -1,8 +1,0 @@
-/**
- * UniversalPassthrough barrel.
- */
-export * from './passthrough-registry.server';
-export * from './passthrough.directive.server';
-export * from './passthrough.module.server';
-
-

--- a/package.json
+++ b/package.json
@@ -1,34 +1,42 @@
 {
   "name": "universal-passthrough",
-  "version": "1.0.1",
-  "description": "seamless server -> browser DOM replacement for @angular universal",
-  "main": "index.server",
-  "typings": "index.server",
-  "browser": "index.browser",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pxwise/universal-passthrough.git"
   },
+  "version": "2.0.0",
+  "description": "seamless server -> browser DOM replacement for @angular universal",
+  "main": "dist/index.server.js",
+  "browser": "dist/index.browser.js",
+  "typings": "universal-passthrough.d.ts",
   "contributors": [
     "PatrickJS <patrick@angularclass.com>",
-    "Shawn Stedman <sstedman@pxwise.com>"
+    "Shawn Stedman <sstedman@pxwise.com>",
+    "Diego Barahona <hi@diegobarahona.com>"
   ],
-  "license": "MIT",
-  "dependencies": {
-    "@angular/common": "~2.1.2",
-    "@angular/compiler": "~2.1.2",
-    "@angular/core": "~2.1.2",
-    "@angular/forms": "~2.1.2",
-    "@angular/http": "~2.1.2",
-    "@angular/platform-browser": "~2.1.2",
-    "@angular/platform-browser-dynamic": "~2.1.2",
-    "@angular/platform-server": "~2.1.2",
-    "rxjs": "5.0.0-beta.12",
-    "zone.js": "~0.6.26"
+  "scripts": {
+    "clean": "rm -rf ./dist",
+    "build": "npm run clean && webpack"
   },
+  "license": "MIT",
   "devDependencies": {
-    "typescript": "^2.0.6",
-    "webpack": "2.1.0-beta.27",
-    "angular2-template-loader": "^0.6.0",
-    "awesome-typescript-loader": "^3.0.0-beta.17"
+    "@angular/animations": "4.0.0",
+    "@angular/common": "4.0.0",
+    "@angular/compiler": "4.0.0",
+    "@angular/core": "4.0.0",
+    "@angular/platform-browser": "4.0.0",
+    "@angular/platform-browser-dynamic": "4.0.0",
+    "@angular/platform-server": "4.0.0",
+    "angular2-template-loader": "0.6.2",
+    "awesome-typescript-loader": "3.1.2",
+    "rxjs": "5.2.0",
+    "ts-node": "^2.1.0",
+    "typescript": "2.2.1",
+    "zone.js": "0.8.5",
+    "webpack": "2.3.1",
+    "webpack-merge": "~0.16.0"
+  },
+  "peerDependencies": {
+    "@angular/core": "^4.0.0"
   }
 }

--- a/passthrough-registry.server.ts
+++ b/passthrough-registry.server.ts
@@ -2,43 +2,30 @@
  * UniversalPassthrough server version, no-op.
  */
 
-/**
- * PassthroughRegistry class definition.
- */
 export class PassthroughRegistry {
-  public serverElements: any = {};
+  /**
+   * Initialize the registry with the server elements
+   */
+  public static init(): void { }
 
-  public isRegistered(id: string): boolean { return true }
-  public replaceElement(id: string, el: HTMLElement): void { }
-  public complete(): void { }
+  /**
+   * Check if the browser element is already registered
+   */
+  public isRegistered(id: string): boolean { return true; }
+
+  /**
+   * Register the browser element
+   * Replace it with corresponding server element if found
+   */
+  public replaceElement(browserId: string, el: HTMLElement): void { }
+
+  /**
+   * Removes the element from DOM
+   */
   public detach(id: string, el: HTMLElement): void { }
+
+  /**
+   * Adds the element to DOM
+   */
   public reattach(id: string, el: HTMLElement): void { }
-  private isElement(): boolean { return false }
-}
-
-/**
- * PassthroughRegistryFactory function.
- */
-export function PassthroughRegistryFactory() {
-  let browserElements = {};
-  let serverElements = {};
-  let isElement = (): boolean => false;
-
-  return {
-    isRegistered: (id: string): boolean => true,
-    replaceElement: (id: string, el: HTMLElement): void => { },
-    complete(serverEls: any): void { },
-    detach: (id: string, el: HTMLElement): void => { },
-    reattach: (id: string, el: HTMLElement): void => { }
-  };
-}
-
-/**
- * passthrough functions to execute in client.ts.
- */
-export function passthrough() {
-  return {
-    getServerElements: (): any => { },
-    complete: (moduleRef: any, serverEls: any): void => { }
-  }
 }

--- a/passthrough.directive.server.ts
+++ b/passthrough.directive.server.ts
@@ -3,4 +3,4 @@ import { Directive } from '@angular/core';
 @Directive({
   selector: '[universalPassthrough]'
 })
-export class UniversalPassthrough {}
+export class UniversalPassthrough { }

--- a/passthrough.module.browser.ts
+++ b/passthrough.module.browser.ts
@@ -1,10 +1,11 @@
 import { NgModule } from '@angular/core';
-import { PassthroughRegistry, PassthroughRegistryFactory } from './passthrough-registry.browser';
+
+import { PassthroughRegistry } from './passthrough-registry.browser';
 import { UniversalPassthrough } from './passthrough.directive.browser';
 
 @NgModule({
   providers: [
-    { provide: PassthroughRegistry, useFactory: PassthroughRegistryFactory }
+    PassthroughRegistry
   ],
   declarations: [
     UniversalPassthrough

--- a/passthrough.module.server.ts
+++ b/passthrough.module.server.ts
@@ -1,10 +1,10 @@
 import { NgModule } from '@angular/core';
-import { PassthroughRegistry, PassthroughRegistryFactory } from './passthrough-registry.server';
+import { PassthroughRegistry } from './passthrough-registry.server';
 import { UniversalPassthrough } from './passthrough.directive.server';
 
 @NgModule({
   providers: [
-    { provide: PassthroughRegistry, useFactory: PassthroughRegistryFactory }
+    PassthroughRegistry
   ],
   declarations: [
     UniversalPassthrough
@@ -13,4 +13,4 @@ import { UniversalPassthrough } from './passthrough.directive.server';
     UniversalPassthrough
   ]
 })
-export class UniversalPassthroughModule {}
+export class UniversalPassthroughModule { }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,22 +5,17 @@
     "experimentalDecorators": true,
     "module": "commonjs",
     "moduleResolution": "node",
-    "outDir": "./",
     "sourceMap": true,
     "sourceRoot": "src",
     "target": "es5",
     "lib": ["es6", "dom"],
-    "types": [],
-    "typeRoots": [
-      "node_modules/@types"
-    ],
     "rootDirs": [
       "./"
     ]
   },
-  "exclude": [
-    "./node_modules",
-    "!node_modules/@types/**/*.d.ts"
+  "files": [
+    "index.browser.ts",
+    "index.server.ts"
   ],
   "awesomeTypescriptLoaderOptions": {
     "useWebpackText": true

--- a/universal-passthorugh.d.ts
+++ b/universal-passthorugh.d.ts
@@ -1,0 +1,13 @@
+declare module "universal-passthrough" {
+  export class UniversalPassthroughModule { }
+
+  export class UniversalPassthrough { }
+
+  export class PassthroughRegistry {
+    public static init(): void
+    public isRegistered(id: string): boolean
+    public replaceElement(browserId: string, el: HTMLElement): void
+    public detach(id: string, el: HTMLElement): void
+    public reattach(id: string, el: HTMLElement): void
+  }
+}

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -1,24 +1,31 @@
-var webpack = require('webpack');
-var path = require('path');
+import * as path from 'path';
+import * as webpack from 'webpack';
+import * as webpackMerge from 'webpack-merge';
 
 var commonConfig = {
   resolve: {
-    extensions: ['.ts', '.js', '.json']
+    extensions: ['.ts', '.js']
+  },
+  output: {
+    path: root('dist'),
+    filename: "[name].js",
+    libraryTarget: 'commonjs'
   },
   module: {
     loaders: [
       // TypeScript
-      { test: /\.ts$/, loaders: ['awesome-typescript-loader', 'angular2-template-loader'] },
-      { test: /\.html$/, loader: 'raw-loader' },
-      { test: /\.css$/, loader: 'raw-loader' },
-      { test: /\.json$/, loader: 'json-loader' }
+      { test: /\.ts$/, loaders: ['awesome-typescript-loader', 'angular2-template-loader'] }
     ],
   },
+  externals: [
+    /^@angular(\\|\/)core/,
+    /^rxjs\//
+  ],
   plugins: [
     new webpack.ContextReplacementPlugin(
       // The (\\|\/) piece accounts for path separators in *nix and Windows
-      /angular(\\|\/)core(\\|\/)src(\\|\/)linker/,
-      root('./src'),
+      /angular(\\|\/)core(\\|\/)@angular/,
+      root('src'),
       {}
     )
   ]
@@ -27,16 +34,8 @@ var commonConfig = {
 var clientConfig = {
   target: 'web',
   entry: {
-    "index.browser": "./index.browser"
+    'index.browser': './index.browser'
   },
-  output: {
-    path: path.resolve(__dirname),
-    filename: "[name].js"
-  },
-  externals: [
-    /^@angular(\\|\/)core/,
-    /^rxjs\//
-  ],
   node: {
     global: true,
     __dirname: true,
@@ -49,17 +48,8 @@ var clientConfig = {
 var serverConfig = {
   target: 'node',
   entry: {
-    "index.server": "./index.server"
+    'index.server': './index.server'
   },
-  output: {
-    path: path.resolve(__dirname),
-    filename: "[name].js",
-    libraryTarget: 'commonjs2'
-  },
-  externals: [
-    /^@angular(\\|\/)core/,
-    /^rxjs\//
-  ],
   node: {
     global: true,
     __dirname: true,
@@ -69,7 +59,6 @@ var serverConfig = {
   }
 };
 
-var webpackMerge = require('webpack-merge');
 module.exports = [
   // Client
   webpackMerge({}, commonConfig, clientConfig),
@@ -78,23 +67,6 @@ module.exports = [
   webpackMerge({}, commonConfig, serverConfig)
 ];
 
-function includeClientPackages(packages) {
-  return function(context, request, cb) {
-    if (packages && packages.indexOf(request) !== -1) {
-      return cb();
-    }
-    return checkNodeImport(context, request, cb);
-  };
-}
-// Helpers
-function checkNodeImport(context, request, cb) {
-  if (!path.isAbsolute(request) && request.charAt(0) !== '.') {
-    cb(null, 'commonjs ' + request); return;
-  }
-  cb();
-}
-
-function root(args) {
-  args = Array.prototype.slice.call(arguments, 0);
-  return path.join.apply(path, [__dirname].concat(args));
+function root(...args: string[]) {
+  return path.join(__dirname, ...args);
 }


### PR DESCRIPTION
Breaking changes:
- `passthrough` function was removed, methods are now static inside `PassthroughRegistry`
- `PassthroughRegistryFactory` was removed

Improved:
- Now we just need to call `PassthroughRegistry.init()` after the document is ready, no need to get the server elements or make a call after bootstrap.

Notes:
- The /dist is being tracked by git, but we can ignore this folder once the package is published in NPM. We need this for now to be able to install the module from github.